### PR TITLE
feat: Add github style classes to the command buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add github style classes to the command buttons ([#26] by @nathan815)
+
 ## [0.3.3] - 2021-01-26
 
 - Host [firefox extension on their developer hub](https://addons.mozilla.org/en-US/firefox/addon/dependabot-clickable-commads/)
@@ -27,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
  - Comment body is now cleared after submitting ([#1] from @ybiquitous)
  
+[#26]: https://github.com/eps1lon/dependabot-clickable-commands/pull/26
 [bfca7f7]: https://github.com/eps1lon/dependabot-clickable-commands/commit/bfca7f73280afa487315f65a4cac5ae0e93ac6bb
 [#1]: https://github.com/eps1lon/dependabot-clickable-commands/pull/1
 [2952a93]: https://github.com/eps1lon/dependabot-clickable-commands/commit/2952a93cd12e70f7d27c77803626abdad3914209

--- a/dependabot-clickable-commands/clickable-commands.js
+++ b/dependabot-clickable-commands/clickable-commands.js
@@ -53,7 +53,10 @@ function main() {
 
       code.appendChild(document.createTextNode(commandTemplate[1])); // "@dependabot ignore this patch version"
     } else {
-      const button = createCommandButton(command, createCommandClickHandler(command));
+      const button = createCommandButton(
+        command,
+        createCommandClickHandler(command)
+      );
       code.parentNode.replaceChild(button, code);
     }
   });

--- a/dependabot-clickable-commands/clickable-commands.js
+++ b/dependabot-clickable-commands/clickable-commands.js
@@ -42,10 +42,8 @@ function main() {
         .slice(1, -1)
         .split("|")
         .forEach((commandValue) => {
-          const button = document.createElement("button");
-          button.appendChild(document.createTextNode(commandValue));
-          button.addEventListener(
-            "click",
+          const button = createCommandButton(
+            commandValue,
             createCommandClickHandler(
               command.replace(alternatives[0], commandValue)
             )
@@ -55,10 +53,7 @@ function main() {
 
       code.appendChild(document.createTextNode(commandTemplate[1])); // "@dependabot ignore this patch version"
     } else {
-      const button = document.createElement("button");
-      button.appendChild(document.createTextNode(command));
-
-      button.addEventListener("click", createCommandClickHandler(command));
+      const button = createCommandButton(command, createCommandClickHandler(command));
       code.parentNode.replaceChild(button, code);
     }
   });
@@ -95,4 +90,18 @@ function findFormOf(input) {
   }
 
   return currentElement;
+}
+
+/**
+ *
+ * @param {string} commandText
+ * @param {EventListener} clickHandler
+ * @returns {HTMLButtonElement}
+ */
+function createCommandButton(commandText, clickHandler) {
+  const button = document.createElement("button");
+  button.appendChild(document.createTextNode(commandText));
+  button.classList.add("btn", "btn-sm");
+  button.addEventListener("click", clickHandler);
+  return button;
 }


### PR DESCRIPTION
Added some GitHub button style classes (btn and btn-sm) to the buttons for a nicer look.

Also extracted the button creation into a function.

Light Mode, Before:
![before - light mode](https://i.imgur.com/tTCuZ2v.png)

Light Mode, After:

![after - light mode](https://i.imgur.com/ZW3lPyL.png)

Dark Mode, Before:
![before -dark mode](https://i.imgur.com/5EY79v8.png)

Dark Mode, After:
![after - dark mode](https://i.imgur.com/UMfY9s7.png)